### PR TITLE
Pass sender to command functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ import pyrc.utils.hooks as hooks
 
 class HiBot(pyrc.Bot):
   @hooks.command()
-  def sayhi(self, channel):
+  def sayhi(self, channel, sender):
     self.message(channel, "hi!")
 
 if __name__ == '__main__':

--- a/example.py
+++ b/example.py
@@ -3,9 +3,9 @@ import pyrc.utils.hooks as hooks
 
 class GangstaBot(pyrc.Bot):
   @hooks.command()
-  def bling(self, channel):
+  def bling(self, channel, sender):
     "will print yo"
-    self.message(channel, "yo")
+    self.message(channel, "%s: yo" % sender)
 
   @hooks.interval(10000)
   def keeprepeating(self):

--- a/pyrc/bots.py
+++ b/pyrc/bots.py
@@ -101,10 +101,10 @@ class Bot(object):
         else:
           raise "This is not a type I've ever heard of."
 
-  def receivemessage(self, channel, nick, message):
-    self.parsecommand(channel, message)
+  def receivemessage(self, channel, sender, message):
+    self.parsecommand(channel, sender, message)
 
-  def parsecommand(self, channel, message):
+  def parsecommand(self, channel, sender, message):
     name = self.name_used(message)
 
     if not name:
@@ -121,9 +121,9 @@ class Bot(object):
           # match.groups() also returns named parameters
           raise "You cannot use both named and unnamed parameters"
         elif group_dict:
-          command_func(self, channel, **group_dict)
+          command_func(self, channel, sender, **group_dict)
         else:
-          command_func(self, channel, *groups)
+          command_func(self, channel, sender, *groups)
         
         if self.config['break_on_match']: break
 


### PR DESCRIPTION
Many commands need a way to notify the nick who sent those commands. For that to work, we'll need to pass the sender argument to the command functions. This pull request does just that.

`example.py` and `README.md` are both updated in this pull request.
