### PR TITLE
Add PRIVMSG hook

### DIFF
--- a/example.py
+++ b/example.py
@@ -7,6 +7,19 @@ class GangstaBot(pyrc.Bot):
     "will print yo"
     self.message(channel, "%s: yo" % sender)
 
+  @hooks.command("^repeat\s+(?P<msg>.+)$")
+  def repeat(self, channel, sender, **kwargs):
+    "will repeat whatever yo say"
+    self.message(channel, "%s: %s" % (sender, kwargs["msg"]))
+
+  @hooks.privmsg("(lol|lmao|rofl(mao)?)")
+  def stopword(self, channel, sender, *args):
+    """
+    will repeat 'lol', 'lmao, 'rofl' or 'roflmao' when seen in a message
+    """
+    print(args)
+    self.message(channel, args[0])
+
   @hooks.interval(10000)
   def keeprepeating(self):
     "will say something"

--- a/pyrc/bots.py
+++ b/pyrc/bots.py
@@ -106,6 +106,8 @@ class Bot(object):
           raise "This is not a type I've ever heard of."
 
   def receivemessage(self, channel, sender, message):
+    message = message.strip()
+
     to_continue = True
     suffix = self.strip_prefix(message)
     if suffix:

--- a/pyrc/utils/hooks.py
+++ b/pyrc/utils/hooks.py
@@ -22,6 +22,21 @@ class command(object):
     wrapped_command._matcher = matcher
     return wrapped_command
 
+class privmsg(object):
+  def __init__(self, matcher=None):
+    self._matcher = matcher
+
+  def __call__(self, func):
+    # convert matcher to regular expression
+    matcher = re.compile(self._matcher)
+
+    @functools.wraps(func)
+    def wrapped_command(*args, **kwargs):
+      return func(*args, **kwargs)
+    wrapped_command._type = "PRIVMSG"
+    wrapped_command._matcher = matcher
+    return wrapped_command
+
 def interval(milliseconds):
   def wrapped(func):
     @functools.wraps(func)


### PR DESCRIPTION
This hook runs when a PRIVMSG is sent to a channel the bot is in or to the bot itself. It works almost exactly the same as a COMMAND except that it does not check for any prefix or nick highlighting.

The test bot was updated to 1) show how hooks.privmsg can be used 2) show how to obtain parameters
