### PR TITLE
Compile regex on init (and add PRIVMSG hook)

### DIFF
--- a/example.py
+++ b/example.py
@@ -5,19 +5,27 @@ class GangstaBot(pyrc.Bot):
   @hooks.command()
   def bling(self, target, sender):
     "will print yo"
-    self.message(target, "%s: yo" % sender)
+    if misc.is_channel(target):
+      self.message(target, "%s: yo" % sender)
+    else:
+      self.message(target, "yo")
 
   @hooks.command("^repeat\s+(?P<msg>.+)$")
   def repeat(self, target, sender, **kwargs):
     "will repeat whatever yo say"
-    self.message(target, "%s: %s" % (sender, kwargs["msg"]))
+    if misc.is_channel(target):
+      self.message(target, kwargs["msg"])
+    else:
+      self.message(sender, kwargs["msg"])
 
   @hooks.privmsg("(lol|lmao|rofl(mao)?)")
   def stopword(self, target, sender, *args):
     """
     will repeat 'lol', 'lmao, 'rofl' or 'roflmao' when seen in a message
+    only applies to channel messages
     """
-    self.message(target, args[0])
+    if misc.is_channel(target):
+      self.message(target, args[0])
 
   @hooks.interval(10000)
   def keeprepeating(self):

--- a/example.py
+++ b/example.py
@@ -17,7 +17,6 @@ class GangstaBot(pyrc.Bot):
     """
     will repeat 'lol', 'lmao, 'rofl' or 'roflmao' when seen in a message
     """
-    print(args)
     self.message(channel, args[0])
 
   @hooks.interval(10000)

--- a/example.py
+++ b/example.py
@@ -7,6 +7,19 @@ class GangstaBot(pyrc.Bot):
     "will print yo"
     self.message(channel, "%s: yo" % sender)
 
+  @hooks.command("^repeat\s+(?P<msg>.+)$")
+  def repeat(self, channel, sender, **kwargs):
+    "will repeat whatever yo say"
+    self.message(channel, "%s: %s" % (sender, kwargs["msg"]))
+
+  @hooks.privmsg("(lol|lmao|rofl(mao)?)")
+  def stopword(self, channel, sender, *args):
+    """
+    will repeat 'lol', 'lmao, 'rofl' or 'roflmao' when seen in a message
+    """
+    print(args)
+    self.message(channel, args[0])
+
   @hooks.interval(10000)
   def keeprepeating(self):
     "will say something"

--- a/example.py
+++ b/example.py
@@ -3,21 +3,21 @@ import pyrc.utils.hooks as hooks
 
 class GangstaBot(pyrc.Bot):
   @hooks.command()
-  def bling(self, channel, sender):
+  def bling(self, target, sender):
     "will print yo"
-    self.message(channel, "%s: yo" % sender)
+    self.message(target, "%s: yo" % sender)
 
   @hooks.command("^repeat\s+(?P<msg>.+)$")
-  def repeat(self, channel, sender, **kwargs):
+  def repeat(self, target, sender, **kwargs):
     "will repeat whatever yo say"
-    self.message(channel, "%s: %s" % (sender, kwargs["msg"]))
+    self.message(target, "%s: %s" % (sender, kwargs["msg"]))
 
   @hooks.privmsg("(lol|lmao|rofl(mao)?)")
-  def stopword(self, channel, sender, *args):
+  def stopword(self, target, sender, *args):
     """
     will repeat 'lol', 'lmao, 'rofl' or 'roflmao' when seen in a message
     """
-    self.message(channel, args[0])
+    self.message(target, args[0])
 
   @hooks.interval(10000)
   def keeprepeating(self):

--- a/pyrc/bots.py
+++ b/pyrc/bots.py
@@ -107,18 +107,18 @@ class Bot(object):
         else:
           raise "This is not a type I've ever heard of."
 
-  def receivemessage(self, channel, sender, message):
+  def receivemessage(self, target, sender, message):
     message = message.strip()
-
     to_continue = True
+    
     suffix = self.strip_prefix(message)
     if suffix:
-      to_continue = self.parsefuncs(channel, sender, suffix, self._commands)
+      to_continue = self.parsefuncs(target, sender, suffix, self._commands)
     
     # if no command was executed
     if to_continue:
       to_continue = self.parsefuncs(channel, sender, message, self._privmsgs)
-
+  
   def parsefuncs(self, channel, sender, message, funcs):
     for func in funcs:
       match = func._matcher.search(message)
@@ -130,7 +130,7 @@ class Bot(object):
           # match.groups() also returns named parameters
           raise "You cannot use both named and unnamed parameters"
         elif group_dict:
-          func(self, channel, sender, **group_dict)
+          func(self, target, sender, **group_dict)
         else:
           func(self, channel, sender, *groups)
 
@@ -207,8 +207,8 @@ class Bot(object):
   def _ping(self, host):
     self.cmd("PONG :%s" % host)
 
-  def _privmsg(self, nick, channel, message):
-    self.receivemessage(channel, nick, message)
+  def _privmsg(self, sender, target, message):
+    self.receivemessage(sender, target, message)
 
   def _invite(self, inviter, channel):
     self.join(channel)

--- a/pyrc/bots.py
+++ b/pyrc/bots.py
@@ -106,6 +106,8 @@ class Bot(object):
           raise "This is not a type I've ever heard of."
 
   def receivemessage(self, channel, sender, message):
+    message = message.strip()
+
     to_continue = True
     suffix = self.strip_prefix(message)
     if suffix:

--- a/pyrc/misc.py
+++ b/pyrc/misc.py
@@ -1,0 +1,2 @@
+def is_channel(target):
+	return target.startswith("#")

--- a/pyrc/utils/hooks.py
+++ b/pyrc/utils/hooks.py
@@ -22,6 +22,21 @@ class command(object):
     wrapped_command._matcher = matcher
     return wrapped_command
 
+class privmsg(object):
+  def __init__(self, matcher=None):
+    self._matcher = matcher
+
+  def __call__(self, func):
+    # convert matcher to regular expression
+    matcher = re.compile(self._matcher)
+
+    @functools.wraps(func)
+    def wrapped_command(*args, **kwargs):
+      return func(*args, **kwargs)
+    wrapped_command._type = "PRIVMSG"
+    wrapped_command._matcher = matcher
+    return wrapped_command
+
 def interval(milliseconds):
   def wrapped(func):
     @functools.wraps(func)


### PR DESCRIPTION
Regular expressions should be compiled on init and not compiled every time they're required.

Due to a branching mistake, this pull request contains https://github.com/sarenji/pyrc/pull/10 , so just pull both.

Message of original pull request:

> This hook runs when a PRIVMSG is sent to a channel the bot is in or to the bot itself. It works almost exactly the same as a COMMAND except that it does not check for any prefix or nick highlighting.
> The test bot was updated to 1) show how hooks.privmsg can be used 2) show how to obtain parameters
